### PR TITLE
Place submit answer button on next line

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -38,6 +38,7 @@
   text-align: center;
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
 

--- a/src/css/party.scss
+++ b/src/css/party.scss
@@ -168,6 +168,7 @@
 .party-input-block {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
 

--- a/src/css/root.scss
+++ b/src/css/root.scss
@@ -156,7 +156,8 @@ input[type=number] {
 }
 
 .submit-answer-btn {
-  flex: 0 0 auto;
+  flex: 0 0 100%;
+  width: 100%;
   min-width: 108px;
   padding: 0 18px;
   border-radius: var(--apple-radius-pill);
@@ -165,10 +166,4 @@ input[type=number] {
   font-size: 17px;
   line-height: 1.2;
   letter-spacing: 0;
-}
-
-@media (max-width: 640px) {
-  .submit-answer-btn {
-    width: 100%;
-  }
 }


### PR DESCRIPTION
[Why] Keep the submit answer button on its own row across all viewport widths.

[How]
- Make the shared submit answer button occupy a full flex row.
- Allow the main and party input containers to wrap so the button always moves below the digit inputs.
- Remove the mobile-only width rule because the layout should apply on every viewport.

[Affected Pages]
- Main game page
- Party game page

---

[中文摘要]
- 調整送出答案按鈕的排列方式，讓它在一般桌面與手機寬度下都固定顯示在輸入欄位下一行。

🤖 Generated with [Codex](https://Codex.com/Codex)
