### PR TITLE
Clear party submit status after both answers

### DIFF
--- a/src/pages/PartyPage/PartyPage.jsx
+++ b/src/pages/PartyPage/PartyPage.jsx
@@ -529,6 +529,7 @@ const PartyPage = () => {
                 pendingSubmit.current = null;
                 setPeerHasSubmitted(false);
                 setSubmittedGuessPreview('');
+                setNotice('');
 
                 const myWin = myEntry.a === 4;
                 const peerWin = peerEntry.a === 4;
@@ -570,6 +571,7 @@ const PartyPage = () => {
         setPeerRecord(updatedPeer);
         setPeerHasSubmitted(false);
         setSubmittedGuessPreview('');
+        setNotice('');
 
         const myWin = myEntry.a === 4;
         const peerWin = peerEntry.a === 4;


### PR DESCRIPTION
[Why] Match the party answer status text to the actual submit state for both players.

[How]
- Clear the status notice when both players' answers are paired and recorded.
- Apply the cleanup to both submit order paths, whether the current player or the peer submitted first.

[Affected Pages]
- Party game page

---

[中文摘要]
- 修正雙方都送出答案後提示字沒有消失的問題，讓尚未送出、等待對方、雙方已送出的狀態顯示符合實際流程。

🤖 Generated with [Codex](https://Codex.com/Codex)
