### PR TITLE
Keep host peer waiting through background switches

### DIFF
--- a/src/pages/PartyPage/PartyPage.jsx
+++ b/src/pages/PartyPage/PartyPage.jsx
@@ -209,7 +209,50 @@ const PartyPage = () => {
         }
     }, []);
 
+    const isHostWaitingForGuest = useCallback(() => (
+        role === 'host'
+        && !connRef.current?.open
+        && (phaseRef.current === PHASE.CONNECTING || phaseRef.current === PHASE.WAITING_TARGET)
+    ), [role]);
+
+    const reconnectHostPeerInBackground = useCallback((error) => {
+        if (!isHostWaitingForGuest()) return false;
+
+        if (error) {
+            logger.info('Host peer issue while waiting for guest; keeping room open in background', error?.type || error?.message || error);
+        }
+
+        connectionIssueRef.current = false;
+        setConnectionIssue(false);
+        setPeerOnline(false);
+        setNotice(formatWording("party.status.waiting.opponent", {}));
+
+        const activePeer = peerRef.current;
+        if (!activePeer || activePeer.destroyed) {
+            setRetryKey((key) => key + 1);
+            return true;
+        }
+
+        const now = Date.now();
+        if (now - signalingReconnectAtRef.current < 15000) return true;
+        signalingReconnectAtRef.current = now;
+
+        if (activePeer.disconnected) {
+            try {
+                activePeer.reconnect();
+            } catch (err) {
+                signalingReconnectAtRef.current = 0;
+                logger.error('Background host peer reconnect failed', err);
+                setRetryKey((key) => key + 1);
+            }
+        }
+
+        return true;
+    }, [isHostWaitingForGuest]);
+
     const showConnectionIssue = useCallback((notice, error) => {
+        if (reconnectHostPeerInBackground(error)) return;
+
         if (error) {
             logger.error(notice, error?.type || error?.message || error);
         } else {
@@ -221,7 +264,7 @@ const PartyPage = () => {
         }
         setPeerOnline(false);
         setNotice(notice);
-    }, [role]);
+    }, [reconnectHostPeerInBackground, role]);
 
     const startConnectionTimer = useCallback(() => {
         clearConnectionTimer();


### PR DESCRIPTION
[Why] Avoid showing a connection failure while the host is only waiting for someone to join.

[How]
- Treat host-side peer issues as non-blocking while no player connection is open yet.
- Keep the room on the waiting state and retry PeerJS preparation in the background.
- Preserve the existing connection failure behavior after a real player connection has been established.

[Affected Pages]
- Party room waiting screen

---

[中文摘要]
- 房主建立房間後切到其他畫面分享連結時，不再因為尚未有玩家連線就顯示連線失敗。
- 等待玩家加入期間會在背景重新準備連線，畫面維持等待狀態。
- 玩家實際連上後的斷線提示仍維持原本行為。

🤖 Generated with [Codex](https://Codex.com/Codex)
