### PR TITLE
Keep invited players in party lobby

### DIFF
--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from "react";
-import { HashRouter, Route, Routes } from "react-router-dom";
+import { HashRouter, Navigate, Route, Routes, useLocation } from "react-router-dom";
 
 /***
  * https://blog.logrocket.com/lazy-loading-components-in-react-16-6-6cea535c0b52/
@@ -25,6 +25,29 @@ import ErrorBoundary from "./component/ErrorBoundary/ErrorBoundary.jsx";
 
 import { formatWording } from "../utils/langUtils";
 
+const ROOM_CODE_PATTERN = /^\d{6}$/;
+
+const PartyRoute = () => {
+    const location = useLocation();
+    const inviteRoomCode = new URLSearchParams(location.search).get('room')?.trim() || '';
+
+    if (inviteRoomCode) {
+        return (
+            <Navigate
+                replace
+                to="/"
+                state={{
+                    stage: "party_setup",
+                    roomID: inviteRoomCode,
+                    notice: ROOM_CODE_PATTERN.test(inviteRoomCode) ? "" : formatWording("error.invalid.inputRoom", {}),
+                }}
+            />
+        );
+    }
+
+    return <PartyPage/>;
+};
+
 const Home = () => {
     return (
         <ErrorBoundary fallback={<p>{formatWording("error.load.page", {})}</p>}>
@@ -32,7 +55,7 @@ const Home = () => {
                 <HashRouter>
                     <Routes>
                         <Route path="/local" element={<MainPage/>}/>
-                        <Route path="/party" element={<PartyPage/>}/>
+                        <Route path="/party" element={<PartyRoute/>}/>
                         <Route path="/" element={<OpeningPageV2/>}/>
                     </Routes>
                 </HashRouter>

--- a/src/pages/PartyPage/PartyPage.jsx
+++ b/src/pages/PartyPage/PartyPage.jsx
@@ -1,7 +1,7 @@
 import '../../css/party.scss';
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { shallowEqual, useSelector, useDispatch } from "react-redux";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { QRCodeSVG } from "qrcode.react";
 import { FiArrowLeft, FiCheck, FiCopy } from "react-icons/fi";
 import { VscDebugRestart } from "react-icons/vsc";
@@ -37,7 +37,6 @@ const HEARTBEAT_TIMEOUT_MS = 20000;
 const RECONNECT_GRACE_MS = 60000;
 const PARTY_SESSION_ID_KEY = 'bulls-cows-party-session-id';
 const PARTY_ROOM_KEY = 'bulls-cows-party-room';
-const ROOM_CODE_PATTERN = /^\d{6}$/;
 
 const savePartyRoom = (role, roomCode) => {
     try { window.sessionStorage.setItem(PARTY_ROOM_KEY, JSON.stringify({ role, roomCode })); } catch { }
@@ -78,7 +77,6 @@ const createTarget = () => shuffleArray(env.GAME.NUMBER_RANGE).slice(0, 4).join(
 
 const PartyPage = () => {
     const navigate = useNavigate();
-    const location = useLocation();
     const dispatch = useDispatch();
     const userName = useSelector(state => state.userReducer.name, shallowEqual);
     const role = useSelector(state => state.partyPageReducer.role, shallowEqual);
@@ -125,7 +123,6 @@ const PartyPage = () => {
     const suppressPeerIssueRef = useRef(false);
     const reconnectTimerRef = useRef(null);
     const copyNoticeTimerRef = useRef(null);
-    const inviteRoomCode = new URLSearchParams(location.search).get('room')?.trim() || '';
     const inviteLink = roomCode
         ? `${window.location.origin}${window.location.pathname}#/party?room=${encodeURIComponent(roomCode)}`
         : '';
@@ -162,19 +159,6 @@ const PartyPage = () => {
     useEffect(() => {
         connectionIssueRef.current = connectionIssue;
     }, [connectionIssue]);
-
-    useEffect(() => {
-        if (!inviteRoomCode) return;
-
-        navigate("/", {
-            replace: true,
-            state: {
-                stage: "party_setup",
-                roomID: inviteRoomCode,
-                notice: ROOM_CODE_PATTERN.test(inviteRoomCode) ? "" : formatWording("error.invalid.inputRoom", {}),
-            },
-        });
-    }, [inviteRoomCode, navigate]);
 
     const clearConnectionTimer = useCallback(() => {
         if (connectionTimerRef.current) {
@@ -698,8 +682,6 @@ const PartyPage = () => {
         let destroyed = false;
 
         const init = async () => {
-            if (inviteRoomCode) return;
-
             try {
                 const savedRoom = loadPartyRoom();
 
@@ -820,7 +802,7 @@ const PartyPage = () => {
             destroyed = true;
             releasePeerResources(false, false);
         };
-    }, [dispatch, inviteRoomCode, releasePeerResources, retryKey, roomID, role, sendMsg, showConnectionIssue, startGame, updatePhase, userName, wireConn]);
+    }, [dispatch, releasePeerResources, retryKey, roomID, role, sendMsg, showConnectionIssue, startGame, updatePhase, userName, wireConn]);
 
     useEffect(() => clearCopyNoticeTimer, [clearCopyNoticeTimer]);
 


### PR DESCRIPTION
[Why] Ensure invite links let guests confirm their name before joining a party room.

[How]
- Handle `/#/party?room=<code>` at the route level and redirect to the lobby party setup before the party room mounts.
- Prefill the room code in the party setup state without starting the join flow.
- Remove the invite redirect effect from the party room page so opening an invite cannot initialize room connection logic first.

[Affected Pages]
- Party invite link
- Party setup

---

[中文摘要]
- 修正從分享連結進入時會直接進入遊戲室的問題，現在會停在派對模式大廳。
- 邀請連結仍會自動帶入房間代碼，但玩家需要先確認名稱並按加入房間才會進入。

🤖 Generated with [Codex](https://Codex.com/Codex)
